### PR TITLE
Test module.import.mount of content with Hugo v0.150.0

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -30,6 +30,9 @@ target="static/foo"
     path="github.com/bep/hugotestmods/mymounts"
     disabled=false
 [[module.imports.mounts]]
+    source="mycontent"
+    target="content/mine"
+[[module.imports.mounts]]
     source="myassets/subfolder"
     target="assets/images"
 [[module.imports.mounts]]

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/bep/my-modular-site
 go 1.12
 
 require (
-	github.com/bep/hugo-fresh v1.0.1 // indirect
 	github.com/bep/hugotestmods/myassets v1.0.4 // indirect
 	github.com/bep/hugotestmods/mymounts v1.2.0 // indirect
 	github.com/bep/hugotestmods/mypartials v1.0.7 // indirect


### PR DESCRIPTION
There are many (old and new) articles/issues/discussions that state that `module.import.mounts` should enable a user to mount directories from a remote repository under `content`, but I've been unable to do so with Hugo v0.150.0

`hugo v0.105.0-0e3b42b4a9bdeb4d866210819fc6ddcf51582ffa+extended darwin/amd64 BuildDate=2022-10-28T12:29:05Z VendorInfo=gohugoio`
`go version go1.19 darwin/amd64`

For [example](https://discourse.gohugo.io/t/hugo-module-imported-mount-appears-as-null/38297/3):

````toml
[module]
[[module.imports]]
  path = 'github.com/MartijnVisser/flink-connector-elasticsearch'
[[module.imports.mounts]]
source = 'docs/content'
target = 'content'
````
and [Master Hugo Modules: Handle Content Or Assets As Modules](https://www.hugofordevelopers.com/articles/master-hugo-modules-handle-content-or-assets-as-modules/)

In an effort to remove myself from the problem, I have forked this repo that has many `mount` config examples - but not one for `content` - to demonstrate that the file `mycontent/article.md` does not get rendered at `/bep/article/`

The exact same `module.import.mount` does work if a `replacement` entry is added pointing at a locally cloned copy of `github.com/bep/hugotestmods/mymounts`.

The mount appears as expected in `hugo config mounts`:

````json
{
   "path": "github.com/bep/hugotestmods/mymounts",
   "version": "v1.2.0",
   "time": "0001-01-01T00:00:00Z",
   "owner": "project",
   "dir": "/Users/metafeather/opt/src/github.com/bep/my-modular-site/_vendor/github.com/bep/hugotestmods/mymounts/",
   "mounts": [
      {
         "source": "mycontent",
         "target": "content/bep"
      },
      {
         "source": "myassets/subfolder",
         "target": "assets/images"
      },
      {
         "source": "mydata/subfolder",
         "target": "data/datakey"
      }
   ]
}
````

Additionally `hugo mod vendor` has copied the `github.com/bep/hugotestmods/mymounts/mycontent` directory as expected.

The content is copied without rendering if the `target` is something other than `content`, e.g. `static`, so I feel this may be a regression - or I am missing something?

Thanks for you consideration.